### PR TITLE
[Update fat.c] fat sector 계산에서 요류 수정 문의드립니다

### DIFF
--- a/filesys/fat.c
+++ b/filesys/fat.c
@@ -139,7 +139,7 @@ void
 fat_boot_create (void) {
 	unsigned int fat_sectors =
 	    (disk_size (filesys_disk) - 1)
-	    / (DISK_SECTOR_SIZE / sizeof (cluster_t) * SECTORS_PER_CLUSTER + 1) + 1;
+	    / (DISK_SECTOR_SIZE / sizeof (cluster_t) * SECTORS_PER_CLUSTER) + 1;
 	fat_fs->bs = (struct fat_boot){
 	    .magic = FAT_MAGIC,
 	    .sectors_per_cluster = SECTORS_PER_CLUSTER,


### PR DESCRIPTION
핀토스 기준에서는 섹터 사이즈가 512이고 클러스터가 int형이기 때문에 한섹터에 담을 수 있는 클러스터는 129가 아닌 128이 맞는 것 같습니다. +1을 제외해야할것 같습니다!